### PR TITLE
Check if DISQUS is defined before including disqus.html

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -15,5 +15,7 @@
       {% endfor %}
     </p>
     {% endif %}
-    {% include "disqus.html" %}
+    {% if DISQUS_SITENAME is defined %}
+        {% include "disqus.html" %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Some people don't need/use Disqus, so checking for `DISQUS_SITENAME` in article.html before including disqus.hmtl looks like a good practice.
