### PR TITLE
Title pull left, Show subtitle

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,14 +17,18 @@ h1, h2                      { margin: 10px 0 25px 0; }
 h1                          { font-size: 48px; line-height: 52px; }
 h2                          { font-size: 36px; line-height: 40px; }
 
+/* colors */
+.muted                      { color: rgb(153, 153, 153); }
+
+
 /* layout elements */
 div.container               { width: 740px; margin: 48px auto; padding: 0; }
 div.header                  { float: left; }
-div.navigation              { float: left; }
-div.navigation a            { text-decoration: none; 
-                              font-size: 22px; 
-                              padding: 10px;
-                            }
+div.navigation              { float: right; }
+div.header a, div.navigation a	{ text-decoration: none; 
+				  font-size: 22px; 
+				  padding: 10px;
+				}
 
 div.separator               {border-bottom: 1px dotted #ddd; padding-bottom: 42px;
                               margin-bottom: 42px; font-size: 16px; color: #888;
@@ -32,7 +36,7 @@ div.separator               {border-bottom: 1px dotted #ddd; padding-bottom: 42p
 div.header, div.navigation  { height: 25px; margin-bottom: 42px; }
 div.navigation ul           { margin: 0; padding: 0; list-style: none; }
 div.navigation ul li        { display: inline; margin: 0 2px; padding: 0;}
-div.body                    { clear: both; }
+div.body                    { clear: both; font-size: 1.1em;}
 div.footer                  { border-top: 1px dotted #ddd; padding-top: 9px;
                               margin-top: 42px; font-size: 16px; color: #888;
                               text-align: center; }

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,9 +1,12 @@
+<div class="header">
+    <a href="{{ SITEURL }}/">{{SITENAME}}</a> <span class="muted">{{SITESUBTITLE}}</span>
+</div>
 
-      <div class=navigation>
-        <ul>
-          {% for section in SECTIONS %}
+<div class=navigation>
+    <ul>
+        {% for section in SECTIONS %}
             <li><a href="{{ SITEURL }}/{{ section[1]}}">{{ section[0] }}</a> </li>
-          {% endfor %}
-        </ul>
-      </div>
-      <div class=separator></div>
+        {% endfor %}
+    </ul>
+</div>
+<div class=separator></div>


### PR DESCRIPTION
Check this one, with a clear separation between blog title and sections the theme looks more like lucumr.pocoo.org and is somewhat easier for the navigation.

![Screenshot](https://f.cloud.github.com/assets/1380243/2527038/3d25d2a8-b500-11e3-9d07-1cc1855d21f1.jpg)
