### PR TITLE
updated to only include icons when links are defined in pelicanconf.py

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -6,19 +6,19 @@
   <p>
     <div class=social style="font-size: 27px;">
       <ul>
-        <script language="JavaScript">
+        {% if MAIL_USERNAME %}<script language="JavaScript">
           u = '{{ MAIL_USERNAME }}';
           s = '{{ MAIL_HOST }}';
           document.write('<a href=\"mailto:' + u + '@' + s + '\" target=\"_blank\">');
         </script>
             <li><i class="icon-envelope icon-large"></i> </li>
-        </a>
-        <a href="http://twitter.com/{{ TWITTER_USERNAME }}" target="_blank"> <li> <i class="icon-twitter-sign icon-large"> </li></i> </a>
-        <a href="{{ LINKEDIN_URL }}" target="_blank"><li><i class="icon-linkedin-sign icon-large" ></i></li></a>
-        <a href="{{ GITHUB_URL }}" target="_blank"> <li> <i class="icon-github-sign icon-large"></i> </li> </a>
-        <a href="{{ FACEBOOK_URL }}" target="_blank"><li> <i class="icon-facebook-sign icon-large"></i></li> </a>
-        <a href="{{ GOOGLEPLUS_URL }}" target="_blank"><li><i class="icon-google-plus-sign icon-large"></i> </li> </a>
-        <a href="{{ PINTEREST_URL }}" target="_blank"><li><i class="icon-pinterest-sign icon-large"></i></li></a>
+        </a>{% endif %}
+        {% if TWITTER_USERNAME %}<a href="http://twitter.com/{{ TWITTER_USERNAME }}" target="_blank"> <li> <i class="icon-twitter-sign icon-large"> </li></i> </a>{% endif %}
+        {% if LINKEDIN_URL %}<a href="{{ LINKEDIN_URL }}" target="_blank"><li><i class="icon-linkedin-sign icon-large" ></i></li></a>{% endif %}
+        {% if GITHUB_URL %}<a href="{{ GITHUB_URL }}" target="_blank"> <li> <i class="icon-github-sign icon-large"></i> </li> </a>{% endif %}
+        {% if FACEBOOK_URL %}<a href="{{ FACEBOOK_URL }}" target="_blank"><li> <i class="icon-facebook-sign icon-large"></i></li> </a>{% endif %}
+        {% if GOOGLEPLUS_URL %}<a href="{{ GOOGLEPLUS_URL }}" target="_blank"><li><i class="icon-google-plus-sign icon-large"></i> </li> </a>{% endif %}
+        {% if PINTEREST_URL %}<a href="{{ PINTEREST_URL }}" target="_blank"><li><i class="icon-pinterest-sign icon-large"></i></li></a>{% endif %}
 
 
         <a href="{{ SITEURL }}/feeds/all.rss.xml" rel="alternate" title="Recent Blog Posts"><li> <i class="icon-rss icon-large"></i> </li></a>


### PR DESCRIPTION
Adding "IF" statements to only include the footer icons and links for those social sites that are defined within the configuration file. 

For example, if you don't specify your Twitter username then you won't see a twitter icon with a broken link in the folder.